### PR TITLE
Standardizes header key resolution across methods

### DIFF
--- a/.changeset/clean-header-keys.md
+++ b/.changeset/clean-header-keys.md
@@ -1,0 +1,11 @@
+---
+"@cerios/playwright-table": patch
+---
+
+Improve header key readability when using header sanitization by normalizing line-ending and control whitespace variants to single spaces when `normalizeWhitespace` is enabled.
+
+This keeps default behavior unchanged (sanitization is still opt-in), while making normalized header text consistent across all header-based methods, including `getJson`, header-name lookups, and distinct-value queries.
+
+Also adds regression and integration tests covering line-ending/control whitespace header scenarios.
+
+Align header-name lookup methods with `getJson` header-key defaults so empty and duplicate header names resolve consistently (for example, `{{Empty}}` and `{{Empty}}__D1`) in methods like `getBodyCellLocatorByRowConditions`, `getAllBodyCellLocatorsByHeaderName`, `getDistinctColumnValues`, and `findRowIndex`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Show Node and npm versions
+        run: |
+          node -v
+          npm -v
+
       - name: Install dependencies
         run: |
-          npm install -g npm@latest
           npm ci
           npx playwright install
 

--- a/src/playwright-table.ts
+++ b/src/playwright-table.ts
@@ -246,7 +246,7 @@ export class PlaywrightTable {
 		targetHeader: string,
 		options?: TableOptions
 	): Promise<Locator> {
-		const table = await this.getTable(options);
+		const table = await this.getTable(this.resolveTableOptionsForHeaderKeyMethods(options));
 		const mainHeader = this.mainHeaderRow(table.headerRows);
 
 		const targetHeaderIndex = this.getHeaderIndex(targetHeader, mainHeader);
@@ -304,7 +304,7 @@ export class PlaywrightTable {
 	 * @see {@link getBodyCellLocatorByRowConditions} for finding specific cells by content
 	 */
 	async getAllBodyCellLocatorsByHeaderName(header: string, options?: TableOptions): Promise<Locator[]> {
-		const table = await this.getTable(options);
+		const table = await this.getTable(this.resolveTableOptionsForHeaderKeyMethods(options));
 		const headers = this.mainHeaderRow(table.headerRows);
 		const headerIndex = this.getHeaderIndex(header, headers);
 		const locators: Locator[] = [];
@@ -380,14 +380,7 @@ export class PlaywrightTable {
 	async getJson(options?: TableOptions): Promise<Record<string, string>[]> {
 		const table = await this.getTable({
 			bodyRowOptions: options?.bodyRowOptions,
-			headerRowOptions: this.resolveHeaderRowOptions(options?.headerRowOptions, {
-				defaultColspanEnabled: true,
-				defaultColspanSuffix: true,
-				defaultDuplicateSuffix: true,
-				defaultEmptyCellReplacement: true,
-				defaultNormalizeWhitespace: false,
-				defaultStripIconGlyphs: false,
-			}),
+			headerRowOptions: this.resolveHeaderRowOptionsForJsonKeys(options?.headerRowOptions),
 		});
 
 		const headers = this.mainHeaderRow(table.headerRows);
@@ -572,7 +565,7 @@ export class PlaywrightTable {
 	 * @see {@link getJson} for getting full table data
 	 */
 	async getDistinctColumnValues(headerName: string, options?: TableOptions): Promise<string[]> {
-		const table = await this.getTable(options);
+		const table = await this.getTable(this.resolveTableOptionsForHeaderKeyMethods(options));
 		const mainHeader = this.mainHeaderRow(table.headerRows);
 		const headerIndex = this.getHeaderIndex(headerName, mainHeader);
 
@@ -612,12 +605,7 @@ export class PlaywrightTable {
 	 * @see {@link waitForRowByConditions} for waiting until matching row appears
 	 */
 	async findRowIndex(conditions: Record<string, string>, options?: TableOptions): Promise<number> {
-		const table = await this.getTable({
-			headerRowOptions: this.resolveHeaderRowOptions(options?.headerRowOptions, {
-				forceColspanEnabled: true,
-			}),
-			bodyRowOptions: options?.bodyRowOptions,
-		});
+		const table = await this.getTable(this.resolveTableOptionsForHeaderKeyMethods(options));
 		const mainHeader = this.mainHeaderRow(table.headerRows);
 
 		// Validate all condition headers exist and get their indices
@@ -690,6 +678,25 @@ export class PlaywrightTable {
 		}
 
 		return options;
+	}
+
+	private resolveHeaderRowOptionsForJsonKeys(headerOptions?: HeaderRowOptions): HeaderRowOptions {
+		return this.resolveHeaderRowOptions(headerOptions, {
+			defaultColspanEnabled: true,
+			defaultColspanSuffix: true,
+			defaultDuplicateSuffix: true,
+			defaultEmptyCellReplacement: true,
+			defaultNormalizeWhitespace: false,
+			defaultStripIconGlyphs: false,
+		});
+	}
+
+	private resolveTableOptionsForHeaderKeyMethods(options?: TableOptions): TableOptions {
+		const tableOptions = this.normalizeGetBodyRowsOptions(options);
+		return {
+			bodyRowOptions: tableOptions.bodyRowOptions,
+			headerRowOptions: this.resolveHeaderRowOptionsForJsonKeys(tableOptions.headerRowOptions),
+		};
 	}
 
 	private resolveHeaderRowOptions(

--- a/src/table-header.ts
+++ b/src/table-header.ts
@@ -37,6 +37,8 @@ export class TableHeader {
 	private static readonly DUPLICATE_SUFFIX_PREFIX = "__D";
 	private static readonly COLSPAN_PATTERN = /__C\d+/;
 	private static readonly ICON_GLYPH_PATTERN = /[\uE000-\uF8FF\u{F0000}-\u{FFFFD}\u{100000}-\u{10FFFD}]/gu;
+	private static readonly CONTROL_WHITESPACE_PATTERN = /[\p{Cc}\p{Zl}\p{Zp}]+/gu;
+	private static readonly WHITESPACE_PATTERN = /\s+/g;
 
 	/**
 	 * Extracts header rows from a table with optional processing for colspan, rowspan, and duplicates.
@@ -173,7 +175,7 @@ export class TableHeader {
 		}
 
 		if (normalizeWhitespace) {
-			result = result.replace(/\s+/g, " ");
+			result = result.replace(this.CONTROL_WHITESPACE_PATTERN, " ").replace(this.WHITESPACE_PATTERN, " ");
 		}
 
 		return result.trim();

--- a/tests/playwright-table.test.ts
+++ b/tests/playwright-table.test.ts
@@ -157,6 +157,28 @@ test.describe("Table Tests", () => {
 			]);
 		});
 
+		test("getJson uses getJson-style empty header names by default", async ({ page }) => {
+			await page.goto(Route.DuplicateEmptyHeadersTable);
+
+			const table = new PlaywrightTable(page.locator("table"));
+			const json = await table.getJson();
+
+			expect(json).toEqual([
+				{
+					"{{Empty}}": "Empty 1_1",
+					"First Name": "Logan",
+					"Last Name": "Veth",
+					"{{Empty}}__D1": "Empty 1_2",
+				},
+				{
+					"{{Empty}}": "Empty 2_1",
+					"First Name": "Deacon",
+					"Last Name": "St. Veth",
+					"{{Empty}}__D1": "Empty 2_2",
+				},
+			]);
+		});
+
 		test("getJson with rowspan handles correctly and returns json with row per rowspan", async ({ page }) => {
 			await page.goto(Route.RowspanRowTable);
 
@@ -317,6 +339,40 @@ test.describe("Table Tests", () => {
 				},
 			]);
 		});
+
+		test("getJson normalizes line-ending header keys when requested", async ({ page }) => {
+			await page.setContent(`
+				<table>
+					<thead>
+						<tr>
+							<th>Account&#10;Name</th>
+							<th>Phone&#13;&#10;Number</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>Mr Test</td>
+							<td>+31612345678</td>
+						</tr>
+					</tbody>
+				</table>
+			`);
+
+			const table = new PlaywrightTable(page.locator("table"));
+			const json = await table.getJson({
+				headerRowOptions: {
+					cellContentType: CellContentType.TextContent,
+					normalizeWhitespace: true,
+				},
+			});
+
+			expect(json).toEqual([
+				{
+					"Account Name": "Mr Test",
+					"Phone Number": "+31612345678",
+				},
+			]);
+		});
 	});
 
 	test("getBodyCellLocator returns locator", async ({ page }) => {
@@ -339,6 +395,15 @@ test.describe("Table Tests", () => {
 		const cellLocator = await table.getBodyCellLocatorByRowConditions({ Rownumber: "Row 2" }, "Delete?");
 		await cellLocator.locator("input[type='button']").click();
 		expect(await table.getBodyRows()).toHaveLength(2);
+	});
+
+	test("getBodyCellLocatorByRowConditions uses getJson-style empty header names by default", async ({ page }) => {
+		await page.goto(Route.DuplicateEmptyHeadersTable);
+
+		const table = new PlaywrightTable(page.locator("table"));
+		const cellLocator = await table.getBodyCellLocatorByRowConditions({ "{{Empty}}": "Empty 1_1" }, "{{Empty}}__D1");
+
+		await expect(cellLocator).toHaveText("Empty 1_2");
 	});
 
 	test("getBodyCellLocatorByRowConditions supports sanitized header names via TableOptions", async ({ page }) => {
@@ -376,6 +441,36 @@ test.describe("Table Tests", () => {
 			headerRowOptions: {
 				normalizeWhitespace: true,
 				stripIconGlyphs: true,
+			},
+		});
+
+		await expect(locator).toHaveText("+31612345678");
+	});
+
+	test("getBodyCellLocatorByRowConditions normalizes line-ending headers when requested", async ({ page }) => {
+		await page.setContent(`
+			<table>
+				<thead>
+					<tr>
+						<th>Account&#10;Name</th>
+						<th>Phone&#13;&#10;Number</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Mr Test</td>
+						<td>+31612345678</td>
+					</tr>
+				</tbody>
+			</table>
+		`);
+
+		const table = new PlaywrightTable(page.locator("table"));
+
+		const locator = await table.getBodyCellLocatorByRowConditions({ "Account Name": "Mr Test" }, "Phone Number", {
+			headerRowOptions: {
+				cellContentType: CellContentType.TextContent,
+				normalizeWhitespace: true,
 			},
 		});
 
@@ -466,6 +561,53 @@ test.describe("Table Tests", () => {
 		expect(await TableBody.getRows(page.locator("table>tbody>tr"), "td")).toHaveLength(0);
 	});
 
+	test("getAllBodyCellLocatorsByHeaderName uses getJson-style empty header names by default", async ({ page }) => {
+		await page.goto(Route.DuplicateEmptyHeadersTable);
+
+		const table = new PlaywrightTable(page.locator("table"));
+		const locators = await table.getAllBodyCellLocatorsByHeaderName("{{Empty}}__D1");
+
+		expect(locators).toHaveLength(2);
+		await expect(locators[0]).toHaveText("Empty 1_2");
+		await expect(locators[1]).toHaveText("Empty 2_2");
+	});
+
+	test("getAllBodyCellLocatorsByHeaderName normalizes line-ending headers when requested", async ({ page }) => {
+		await page.setContent(`
+			<table>
+				<thead>
+					<tr>
+						<th>Account&#10;Name</th>
+						<th>Phone&#13;&#10;Number</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Mr Test</td>
+						<td>+31612345678</td>
+					</tr>
+					<tr>
+						<td>Ms Demo</td>
+						<td>+441234567890</td>
+					</tr>
+				</tbody>
+			</table>
+		`);
+
+		const table = new PlaywrightTable(page.locator("table"));
+
+		const locators = await table.getAllBodyCellLocatorsByHeaderName("Phone Number", {
+			headerRowOptions: {
+				cellContentType: CellContentType.TextContent,
+				normalizeWhitespace: true,
+			},
+		});
+
+		expect(locators).toHaveLength(2);
+		await expect(locators[0]).toHaveText("+31612345678");
+		await expect(locators[1]).toHaveText("+441234567890");
+	});
+
 	test("getAllBodyCellLocatorsByHeaderIndex returns locators", async ({ page }) => {
 		await page.goto(Route.ButtonTable);
 
@@ -479,6 +621,15 @@ test.describe("Table Tests", () => {
 			await locator.locator("input[type='button']").click();
 		}
 		expect(await TableBody.getRows(page.locator("table>tbody>tr"), "td")).toHaveLength(0);
+	});
+
+	test("findRowIndex uses getJson-style empty header names by default", async ({ page }) => {
+		await page.goto(Route.DuplicateEmptyHeadersTable);
+
+		const table = new PlaywrightTable(page.locator("table"));
+		const rowIndex = await table.findRowIndex({ "{{Empty}}": "Empty 2_1", "First Name": "Deacon" });
+
+		expect(rowIndex).toBe(1);
 	});
 
 	test("div table", async ({ page }) => {
@@ -546,6 +697,48 @@ test.describe("getDistinctColumnValues", () => {
 		const firstNames = await table.getDistinctColumnValues("First name");
 
 		expect(firstNames).toEqual(["Logan", "Ronald"]);
+	});
+
+	test("should normalize line-ending headers when requested", async ({ page }) => {
+		await page.setContent(`
+			<table>
+				<thead>
+					<tr>
+						<th>Account&#10;Name</th>
+						<th>Phone&#13;&#10;Number</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Mr Test</td>
+						<td>+31612345678</td>
+					</tr>
+					<tr>
+						<td>Ms Demo</td>
+						<td>+441234567890</td>
+					</tr>
+				</tbody>
+			</table>
+		`);
+
+		const table = new PlaywrightTable(page.locator("table"));
+		const values = await table.getDistinctColumnValues("Account Name", {
+			headerRowOptions: {
+				cellContentType: CellContentType.TextContent,
+				normalizeWhitespace: true,
+			},
+		});
+
+		expect(values).toEqual(["Mr Test", "Ms Demo"]);
+	});
+
+	test("should use getJson-style empty header names by default", async ({ page }) => {
+		await page.goto(Route.DuplicateEmptyHeadersTable);
+		const table = new PlaywrightTable(page.locator("table"));
+
+		const values = await table.getDistinctColumnValues("{{Empty}}");
+
+		expect(values).toEqual(["Empty 1_1", "Empty 2_1"]);
 	});
 
 	test("should exclude empty values", async ({ page }) => {

--- a/tests/table-header.test.ts
+++ b/tests/table-header.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { CellContentType } from "src/cell-content-type";
 import { HeaderRow } from "src/row";
 import { TableHeader } from "src/table-header";
 
@@ -24,6 +25,55 @@ test.describe("Header Row Tests", () => {
 			});
 
 			expect(headers).toEqual([["Account name Sort", "City Name"]]);
+		});
+
+		test("normalizeWhitespace collapses line-ending and control whitespace variants", async ({ page }) => {
+			await page.setContent(`
+				<table>
+					<thead>
+						<tr>
+							<th>Account&#10;Name</th>
+							<th>Phone&#13;&#10;Number</th>
+							<th>User&#13;Type</th>
+							<th>Status&#x2028;Label</th>
+							<th id="code-header">CodeValue</th>
+						</tr>
+					</thead>
+				</table>
+			`);
+
+			await page.evaluate(() => {
+				const controlHeader = document.getElementById("code-header");
+				if (controlHeader) {
+					controlHeader.textContent = "Code\u0085Value";
+				}
+			});
+
+			const headers = await TableHeader.getRows(page.locator("table>thead>tr"), "th", {
+				cellContentType: CellContentType.TextContent,
+				normalizeWhitespace: true,
+			});
+
+			expect(headers).toEqual([["Account Name", "Phone Number", "User Type", "Status Label", "Code Value"]]);
+		});
+
+		test("normalizeWhitespace false preserves explicit line breaks in header text", async ({ page }) => {
+			await page.setContent(`
+				<table>
+					<thead>
+						<tr>
+							<th>Account&#10;Name</th>
+						</tr>
+					</thead>
+				</table>
+			`);
+
+			const headers = await TableHeader.getRows(page.locator("table>thead>tr"), "th", {
+				cellContentType: CellContentType.TextContent,
+				normalizeWhitespace: false,
+			});
+
+			expect(headers).toEqual([["Account\nName"]]);
 		});
 
 		test("stripIconGlyphs removes private-use icon font characters", async ({ page }) => {


### PR DESCRIPTION
Consolidates header processing logic to ensure consistent behavior when methods use header names as keys (getJson, findRowIndex, getBodyCellLocatorByRowConditions, etc.).

Introduces helper methods to apply JSON-style header transformations (colspan handling, duplicate suffixes, empty cell replacements) by default across all methods that match rows or cells by header name.

Improves whitespace normalization to properly handle line endings and control characters in header text when normalizeWhitespace is enabled, replacing them with regular spaces instead of preserving them.

Ensures empty headers and duplicate headers receive consistent placeholder names ({{Empty}}, __D1 suffixes) across all header-key-based operations, not just getJson.